### PR TITLE
Handle readlink results correctly

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -23,10 +23,9 @@ docker run \
   bash -c "./bootstrap.sh && \
            ./configure && \
            make -j$(grep -c ^processor /proc/cpuinfo) && \
-           make check-valgrind"
-# TODO:
-#           export LD_LIBRARY_PATH=${ROOT_DIR}/parser/.libs && \
-#           for I in ${ROOT_DIR}/test/data/*.bin; do \
-#             valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all \
-#               ${ROOT_DIR}/util/.libs/esel --file \${I} >/dev/null; \
-#           done"
+           make check-valgrind && \
+           export LD_LIBRARY_PATH=${ROOT_DIR}/parser/.libs && \
+           for I in ${ROOT_DIR}/test/data/*.bin; do \
+             valgrind --tool=memcheck --error-exitcode=1 \
+               ${ROOT_DIR}/util/.libs/esel --file \${I} >/dev/null || exit 1; \
+           done"

--- a/hbplugins/fsp_trace.cpp
+++ b/hbplugins/fsp_trace.cpp
@@ -70,12 +70,13 @@ class TempFile
         // Get absolute path to the temporary file
         std::string link = std::string("/proc/self/fd/") + std::to_string(fd_);
         char path[PATH_MAX];
-        if (readlink(link.c_str(), path, sizeof(path)) == -1)
+        const ssize_t len = readlink(link.c_str(), path, sizeof(path));
+        if (len == -1)
         {
             throw std::system_error(errno, std::system_category(),
                                     "Unable to get temporary file name");
         }
-        path_ = path;
+        path_.assign(path, path + len);
     }
 
     /**


### PR DESCRIPTION
readlink doesn't add null at the end of the result string.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>