### PR TITLE
Fix build with OpenBMC 2.10.0-dev

### DIFF
--- a/parser/fmtexcept.hpp
+++ b/parser/fmtexcept.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstring>
 #include <exception>
 #include <string>
 
@@ -30,6 +31,8 @@ namespace eSEL
  */
 class InvalidFormat : public std::exception
 {
+    static constexpr auto defaultMessage = "Invalid format";
+
   public:
     /**
      * @brief Constructor.
@@ -39,7 +42,6 @@ class InvalidFormat : public std::exception
     template <typename... A>
     InvalidFormat(const char* fmt, A&&... args)
     {
-        static const char* defaultMessage = "Invalid format";
         if (!fmt)
             msg_ = defaultMessage;
         else
@@ -54,6 +56,10 @@ class InvalidFormat : public std::exception
                          std::forward<A>(args)...);
             }
         }
+    }
+    InvalidFormat(const char* message)
+    {
+        msg_ = (!message || strlen(message) == 0) ? defaultMessage : message;
     }
 
     const char* what() const noexcept override


### PR DESCRIPTION
The build with OpenBMC 2.10.0-dev fails.
It uses GCC-10.2.0 and an error message looks like:
```
parser/fmtexcept.hpp: In instantiation of 'eSEL::InvalidFormat::InvalidFormat(const char*, A&& ...) [with A = {}]':
parser/event.cpp:107:51:   required from here
parser/fmtexcept.hpp:47:37: error: format not a string literal and no format arguments [-Werror=format-security]
  47 |             const int len = snprintf(nullptr, 0, fmt, std::forward<A>(args)...);
     |                             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
parser/fmtexcept.hpp:53:25: error: format not a string literal and no format arguments [-Werror=format-security]
   53 |                 snprintf(msg_.data(), msg_.size(), fmt,
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   54 |                          std::forward<A>(args)...);
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~
```

This brings an overloaded constructor with only one argument and fixes
the build.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>